### PR TITLE
Add ArnoldC adapter

### DIFF
--- a/adapters/arnoldc.arnoldc
+++ b/adapters/arnoldc.arnoldc
@@ -1,0 +1,3 @@
+IT'S SHOWTIME
+TALK TO THE HAND "Connection established!"
+YOU HAVE BEEN TERMINATED


### PR DESCRIPTION
Clearly we can't release a 2.0 without ArnoldC support. This huge milestone will be embraced by our millions of enterprise customers.